### PR TITLE
move CIScripts to AnalyzerTool

### DIFF
--- a/ci-scripts/Analyzer/Analyzer.php
+++ b/ci-scripts/Analyzer/Analyzer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer;
 
 use Exception;
 use RuntimeException;

--- a/ci-scripts/Analyzer/AnalyzerSettings.php
+++ b/ci-scripts/Analyzer/AnalyzerSettings.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer;
 
 use Exception;
-use Oscabrera\ModelRepository\CIScripts\Analyzer\Constants\Color;
-use Oscabrera\ModelRepository\CIScripts\Analyzer\Constants\Icon;
+use Oscabrera\AnalyzerTool\CIScripts\Analyzer\Constants\Color;
+use Oscabrera\AnalyzerTool\CIScripts\Analyzer\Constants\Icon;
 use RuntimeException;
 
 /**

--- a/ci-scripts/Analyzer/ArgumentHandler.php
+++ b/ci-scripts/Analyzer/ArgumentHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer;
 
 class ArgumentHandler
 {

--- a/ci-scripts/Analyzer/CommandBuilder.php
+++ b/ci-scripts/Analyzer/CommandBuilder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer;
 
 class CommandBuilder
 {

--- a/ci-scripts/Analyzer/Constants/Color.php
+++ b/ci-scripts/Analyzer/Constants/Color.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer\Constants;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer\Constants;
 
 class Color
 {

--- a/ci-scripts/Analyzer/Constants/Icon.php
+++ b/ci-scripts/Analyzer/Constants/Icon.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer\Constants;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer\Constants;
 
 class Icon
 {

--- a/ci-scripts/Analyzer/FileHandler.php
+++ b/ci-scripts/Analyzer/FileHandler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Analyzer;
+namespace Oscabrera\AnalyzerTool\CIScripts\Analyzer;
 
 use RuntimeException;
 

--- a/ci-scripts/PhpMD/PhpMDAnalyzer.php
+++ b/ci-scripts/PhpMD/PhpMDAnalyzer.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\PhpMD;
+namespace Oscabrera\AnalyzerTool\CIScripts\PhpMD;
 
-use Oscabrera\ModelRepository\CIScripts\Analyzer\Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\Analyzer\Analyzer;
 
 class PhpMDAnalyzer extends Analyzer
 {
@@ -18,9 +18,7 @@ class PhpMDAnalyzer extends Analyzer
         parent::__construct(
             'PHP Mess Detector',
             <<<CMD
-            ./vendor/bin/phpmd %FILES% ansi \\
-            cleancode,codesize,controversial,design,unusedcode \\
-            --exclude *vendor
+            ./vendor/bin/phpmd %FILES% ansi cleancode,codesize,controversial,design,unusedcode --exclude *vendors
             CMD,
             $args
         );

--- a/ci-scripts/PhpMD/run.php
+++ b/ci-scripts/PhpMD/run.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts;
+namespace Oscabrera\AnalyzerTool\CIScripts;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Oscabrera\ModelRepository\CIScripts\PhpMD\PhpMDAnalyzer as Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\PhpMD\PhpMDAnalyzer as Analyzer;
 
 exit((new Analyzer(array_slice($_SERVER['argv'], 1)))->analyze() ? 0 : 1);

--- a/ci-scripts/PhpStan/PhpStanAnalyzer.php
+++ b/ci-scripts/PhpStan/PhpStanAnalyzer.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\PhpStan;
+namespace Oscabrera\AnalyzerTool\CIScripts\PhpStan;
 
-use Oscabrera\ModelRepository\CIScripts\Analyzer\Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\Analyzer\Analyzer;
 
 class PhpStanAnalyzer extends Analyzer
 {
@@ -17,10 +17,7 @@ class PhpStanAnalyzer extends Analyzer
         parent::__construct(
             'PHPStan',
             <<<CMD
-            ./vendor/bin/phpstan analyse \\
-            --memory-limit=1G \\
-            -c ci-scripts/PhpStan/phpstan.neon \\
-            --ansi %FILES%
+            ./vendor/bin/phpstan analyse --memory-limit=1G -c ci-scripts/PhpStan/phpstan.neon --ansi %FILES%
             CMD,
             $args
         );

--- a/ci-scripts/PhpStan/run.php
+++ b/ci-scripts/PhpStan/run.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts;
+namespace Oscabrera\AnalyzerTool\CIScripts;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Oscabrera\ModelRepository\CIScripts\PhpStan\PhpStanAnalyzer as Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\PhpStan\PhpStanAnalyzer as Analyzer;
 
 exit((new Analyzer(array_slice($_SERVER['argv'], 1)))->analyze() ? 0 : 1);

--- a/ci-scripts/Pint/PintAnalyzer.php
+++ b/ci-scripts/Pint/PintAnalyzer.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts\Pint;
+namespace Oscabrera\AnalyzerTool\CIScripts\Pint;
 
-use Oscabrera\ModelRepository\CIScripts\Analyzer\Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\Analyzer\Analyzer;
 
 class PintAnalyzer extends Analyzer
 {
@@ -17,9 +17,7 @@ class PintAnalyzer extends Analyzer
         parent::__construct(
             'Pint',
             <<<CMD
-            ./vendor/bin/pint --test --config \\
-            ci-scripts/Pint/pint.json \\
-            --ansi %FILES%
+            ./vendor/bin/pint --test --config ci-scripts/Pint/pint.json --ansi %FILES%
             CMD,
             $args
         );

--- a/ci-scripts/Pint/run.php
+++ b/ci-scripts/Pint/run.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Oscabrera\ModelRepository\CIScripts;
+namespace Oscabrera\AnalyzerTool\CIScripts;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Oscabrera\ModelRepository\CIScripts\Pint\PintAnalyzer as Analyzer;
+use Oscabrera\AnalyzerTool\CIScripts\Pint\PintAnalyzer as Analyzer;
 
 exit((new Analyzer(array_slice($_SERVER['argv'], 1)))->analyze() ? 0 : 1);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "autoload": {
         "psr-4": {
             "Oscabrera\\ModelRepository\\": "src/",
-            "Oscabrera\\ModelRepository\\CIScripts\\": "ci-scripts/"
+            "Oscabrera\\AnalyzerTool\\CIScripts\\": "ci-scripts/"
         }
     },
     "require": {
@@ -50,7 +50,6 @@
         "phpstan": "php ci-scripts/PhpStan/run.php",
         "pint": "php ci-scripts/Pint/run.php",
         "phpmd": "php ci-scripts/PhpMD/run.php"
-
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
The intention of moving CIScripts to Analyzer Tool is to stop depending on the package so that in the future it can be converted into a package and not replicate code in other repositories.


Move commands from multiline to one line