### PR TITLE
Update GitHub Actions and improve exclusions

### DIFF
--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -3,8 +3,13 @@ name: PHPMD
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:
@@ -12,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -25,7 +30,7 @@ jobs:
             composer-
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,8 +6,13 @@ name: PHPStan
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:
@@ -15,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -28,7 +33,7 @@ jobs:
             composer-
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -3,8 +3,13 @@ name: Pint
 
 on:
   push:
-    branches:
-      - 'Feature/*'
+    branches-ignore:
+      - 'main'
+      - 'develop'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'develop'
 
 jobs:
   phpstan:
@@ -12,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -25,7 +30,7 @@ jobs:
             composer-
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/ci-scripts/PhpMD/PhpMDAnalyzer.php
+++ b/ci-scripts/PhpMD/PhpMDAnalyzer.php
@@ -18,7 +18,7 @@ class PhpMDAnalyzer extends Analyzer
         parent::__construct(
             'PHP Mess Detector',
             <<<CMD
-            ./vendor/bin/phpmd %FILES% ansi cleancode,codesize,controversial,design,unusedcode --exclude *vendors
+            ./vendor/bin/phpmd %FILES% ansi cleancode,codesize,controversial,design,unusedcode --exclude *vendor/
             CMD,
             $args,
         );

--- a/ci-scripts/Pint/pint.json
+++ b/ci-scripts/Pint/pint.json
@@ -1,3 +1,6 @@
 {
-    "preset": "per"
+    "preset": "per",
+    "exclude": [
+        "vendor/"
+    ]
 }


### PR DESCRIPTION
✨ feat: exclude `main` and `develop` branches in workflows
📦 build: upgrade GitHub Actions to use latest versions (`checkout@v4`, `cache@v4`)
🐛 fix: correct `--exclude` path in PhpMDAnalyzer.php
🔧 chore: update `pint.json` to exclude `vendor/` directory